### PR TITLE
Update version number in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-engine",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR updates the version number in the `package-lock.json` file for 4.0.0.