### PR TITLE
Escalate errors on RPC responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,6 @@ engine.push(function(req, res, next, end){
   end(new Error())
 })
 ```
+
+That said, `next()` will detect errors on the RPC response, and cause
+`end(res.error)` to be called.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-engine",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7313,9 +7313,12 @@
       "dev": true
     },
     "eth-json-rpc-errors": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-0.3.1.tgz",
-      "integrity": "sha512-TUBUzAzl0ccQ94ygajkUUctw6Gql0PbgK5J7tD6v9hGk2yKiML+U6HjG9up2AMe15dlMQW33zDjwAerNjDRsYQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.0.1.tgz",
+      "integrity": "sha512-Z3iESIy5x2m9Phe/H885E3RWifZ/K+T08CUwd3djcUILwxP+XoMI9+Jspv1UkMcFlZFKigzOGZinIzmOpvBLhg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
     },
     "eventemitter3": {
       "version": "3.1.2",
@@ -7696,6 +7699,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
     "fastq": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-engine",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "a tool for processing JSON RPC",
   "license": "ISC",
   "author": "kumavis",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "async": "^2.0.1",
-    "eth-json-rpc-errors": "^0.3.1",
+    "eth-json-rpc-errors": "^1.0.1",
     "promise-to-callback": "^1.0.0",
     "safe-event-emitter": "^1.0.1"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 
-import { IJsonRpcError } from 'eth-json-rpc-errors'
+import { IJsonRpcError } from 'eth-json-rpc-errors/@types'
 
 /** A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0". */
 export type JsonRpcVersion = "2.0";

--- a/src/index.js
+++ b/src/index.js
@@ -97,16 +97,22 @@ class RpcEngine extends SafeEventEmitter {
       middleware(req, res, next, end)
 
       function next (returnHandler) {
-        // add return handler
-        allReturnHandlers.push(returnHandler)
-        cb()
+        if (res.error) {
+          end(res.error)
+        } else {
+          // add return handler
+          allReturnHandlers.push(returnHandler)
+          cb()
+        }
       }
 
       function end (err) {
         // if errored, set the error but dont pass to callback
-        if (err) {
-          res.error = serializeError(err)
-          res._originalError = err
+        const _err = err || (res && res.error)
+        // const _err = err
+        if (_err) {
+          res.error = serializeError(_err)
+          res._originalError = _err
         }
         // mark as completed
         isComplete = true
@@ -120,6 +126,8 @@ class RpcEngine extends SafeEventEmitter {
       if (err) {
         // prepare error message
         res.error = serializeError(err)
+        // remove result if present
+        delete res.result
         // return error-first and res with err
         return onDone(err, res)
       }

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -84,7 +84,7 @@ describe('basic tests', function () {
     })
   })
 
-  it('erroring middleware test', function (done) {
+  it('erroring middleware test: end(error)', function (done) {
     let engine = new RpcEngine()
 
     engine.push(function (req, res, next, end) {
@@ -97,6 +97,45 @@ describe('basic tests', function () {
       assert(err, 'did error')
       assert(res, 'does have response')
       assert(res.error, 'does have error on response')
+      assert(!res.result, 'does not have result on response')
+      done()
+    })
+  })
+
+  it('erroring middleware test: res.error -> next()', function (done) {
+    let engine = new RpcEngine()
+
+    engine.push(function (req, res, next, end) {
+      res.error = new Error('no bueno')
+      next()
+    })
+
+    let payload = { id: 1, jsonrpc: '2.0', method: 'hello' }
+
+    engine.handle(payload, function (err, res) {
+      assert(err, 'did error')
+      assert(res, 'does have response')
+      assert(res.error, 'does have error on response')
+      assert(!res.result, 'does not have result on response')
+      done()
+    })
+  })
+
+  it('erroring middleware test: res.error -> end()', function (done) {
+    let engine = new RpcEngine()
+
+    engine.push(function (req, res, next, end) {
+      res.error = new Error('no bueno')
+      end()
+    })
+
+    let payload = { id: 1, jsonrpc: '2.0', method: 'hello' }
+
+    engine.handle(payload, function (err, res) {
+      assert(err, 'did error')
+      assert(res, 'does have response')
+      assert(res.error, 'does have error on response')
+      assert(!res.result, 'does not have result on response')
       done()
     })
   })


### PR DESCRIPTION
Errors on RPC responses are now detected in the `next()` and `end()` handlers and they are escalated as though `end(response.error)` was called.

Responses are also sanitized by deleting `response.result` if `response.error` is present, as mandated by the JSON RPC 2.0 spec.

Version bump: `5.1.2` -> `5.1.3`

Fixes #11 