### PR TITLE
Update batch request behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8829,7 +8829,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -8866,7 +8866,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -9536,9 +9536,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -13315,7 +13315,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -13333,7 +13333,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -16800,9 +16800,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-engine",
-  "version": "5.1.4",
+  "version": "5.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8829,7 +8829,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -8866,7 +8866,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -13315,7 +13315,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -13333,7 +13333,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-engine",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "a tool for processing JSON RPC",
   "license": "ISC",
   "author": "kumavis",

--- a/src/index.js
+++ b/src/index.js
@@ -30,51 +30,28 @@ class RpcEngine extends SafeEventEmitter {
   // Private
   //
 
-  _handleBatch (reqs, cb) {
+  async _handleBatch (reqs, cb) {
 
-    let numRemaining = reqs.length // keep track of number of remaining requests
-    const batchRes = new Array(reqs.length).fill(null) // responses, in order
-
-    // loop over requests
-    for (let i = 0; i < batchRes.length; i++) {
-
-      // fire off all requests in sequence without waiting for resolution
-      // in this way, the receiver can handle them as an ordered batch
-      this._promiseHandle(reqs[i], i)
-        .then(([err, res, index]) => {
-
-          if (!res) { // this is bad
-            if (err) {
-              throw err
-            } else {
-              throw ethErrors.rpc.internal('JsonRpcEngine: Request handler returned neither error nor response.')
-            }
-          } else {
-
-            // add individual response in order to response array
-            batchRes[index] = res
-
-            // call callback if all requests handled
-            numRemaining--
-            if (numRemaining === 0) {
-              cb && cb(null, batchRes)
-              cb = null // should not be necessary, but nevertheless...
-            }
-          }
-        })
-        .catch(_err => {
-
-          // some kind of fatal error
-          cb && cb(_err, null)
-          cb = null // don't let anyone else call cb
-        })
+    try {
+      const batchRes = await Promise.all(
+        reqs.map(this._promiseHandle.bind(this))
+      )
+      cb(null, batchRes)
+    } catch (err) {
+      cb(err)
     }
   }
 
-  _promiseHandle (req, index) {
-    return new Promise((resolve) => {
+  _promiseHandle (req) {
+    return new Promise((resolve, reject) => {
       this._handle(req, (err, res) => {
-        resolve([err, res, index])
+        if (!res) {
+          reject(err || ethErrors.rpc.internal(
+            'JsonRpcEngine: Request handler returned neither error nor response.'
+          ))
+        } else {
+          resolve(res)
+        }
       })
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -32,20 +32,22 @@ class RpcEngine extends SafeEventEmitter {
 
   async _handleBatch (reqs, cb) {
 
+    // The order here is important
     try {
-      const batchRes = await Promise.all(
+      const batchRes = await Promise.all( // 2. Wait for all requests to finish
+        // 1. Begin executing each request in the order received
         reqs.map(this._promiseHandle.bind(this))
       )
-      cb(null, batchRes)
+      cb(null, batchRes) // 3a. Return batch response
     } catch (err) {
-      cb(err)
+      cb(err) // 3b. Some kind of fatal error; all requests are lost
     }
   }
 
   _promiseHandle (req) {
     return new Promise((resolve, reject) => {
       this._handle(req, (err, res) => {
-        if (!res) {
+        if (!res) { // defensive programming
           reject(err || ethErrors.rpc.internal(
             'JsonRpcEngine: Request handler returned neither error nor response.'
           ))

--- a/src/mergeMiddleware.js
+++ b/src/mergeMiddleware.js
@@ -1,4 +1,3 @@
-const each = require('async/each')
 const JsonRpcEngine = require('./index')
 const asMiddleware = require('./asMiddleware')
 

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -154,10 +154,10 @@ describe('basic tests', function () {
   it('handle batch payloads', function (done) {
     let engine = new RpcEngine()
 
-    engine.push(function (req, res, next, end) {
+    engine.push(function (req, res, _next, end) {
       if (req.id === 4) {
         delete res.result
-        res.error = new Error()
+        res.error = new Error('foobar')
         return end(res.error)
       }
       res.result = req.id


### PR DESCRIPTION
Update ordered batch behavior again. The previous fix guaranteed that requests were made in the correct order, but each request had to generate a response before the subsequent request was sent to the recipient.

Now, batch requests are still made and returned in the correct order, but all requests are now submitted at once, in order to let the recipient implement better batch request handling.

Miscellanea
- Bumps version to `5.1.6`, so ready to publish immediately upon merged
- Delete unused import in one file