### PR TITLE
Add destroy function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,12 +54,11 @@ interface JsonRpcMiddleware {
     next: JsonRpcEngineNextCallback,
     end: JsonRpcEngineEndCallback,
   ) : void;
-  destroy?: () => void;
 }
 
 interface JsonRpcEngine {
   push: (middleware: JsonRpcMiddleware) => void;
   handle: (req: JsonRpcRequest<any>, callback: (error: JsonRpcError<any>, res: JsonRpcResponse<any>) => void) => void;
   destroy: () => void;
-  isActive: () => boolean;
+  isDestroyed: () => boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,10 +54,12 @@ interface JsonRpcMiddleware {
     next: JsonRpcEngineNextCallback,
     end: JsonRpcEngineEndCallback,
   ) : void;
+  destroy?: () => void;
 }
 
 interface JsonRpcEngine {
   push: (middleware: JsonRpcMiddleware) => void;
   handle: (req: JsonRpcRequest<any>, callback: (error: JsonRpcError<any>, res: JsonRpcResponse<any>) => void) => void;
+  destroy: () => void;
+  isActive: () => boolean;
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const {
   serializeError, EthereumRpcError, ERROR_CODES,
 } = require('eth-json-rpc-errors')
 
-const DESTROYED_ERROR_MESSAGE = 'This engine is destroyed; please initialize a new engine.'
+const DESTROYED_ERROR_MESSAGE = 'JsonRpcEngine: This engine is destroyed; please initialize a new engine.'
 
 module.exports = class RpcEngine extends SafeEventEmitter {
 
@@ -21,16 +21,20 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   //
 
   push (middleware) {
+
     if (this._isDestroyed) {
       throw new Error(DESTROYED_ERROR_MESSAGE)
     }
+
     this._middleware.push(middleware)
   }
 
   handle (req, cb) {
+
     if (this._isDestroyed) {
       throw new Error(DESTROYED_ERROR_MESSAGE)
     }
+
     // batch request support
     if (Array.isArray(req)) {
       this._handleBatch(req, cb)
@@ -92,6 +96,11 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   }
 
   _handle (_req, cb) {
+
+    if (this._isDestroyed) {
+      throw new Error(DESTROYED_ERROR_MESSAGE)
+    }
+
     // shallow clone request object
     const req = { ..._req }
     // create response obj

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const {
   serializeError, EthereumRpcError, ERROR_CODES,
 } = require('eth-json-rpc-errors')
 
-const DEACTIVATED_ERROR = 'Engine is deactivated; please initialize new engine.'
+const DEACTIVATED_ERROR_MESSAGE = 'Engine is deactivated; please initialize new engine.'
 
 module.exports = class RpcEngine extends SafeEventEmitter {
 
@@ -22,14 +22,14 @@ module.exports = class RpcEngine extends SafeEventEmitter {
 
   push (middleware) {
     if (!this._isActive) {
-      throw new Error(DEACTIVATED_ERROR)
+      throw new Error(DEACTIVATED_ERROR_MESSAGE)
     }
     this._middleware.push(middleware)
   }
 
   handle (req, cb) {
     if (!this._isActive) {
-      throw new Error(DEACTIVATED_ERROR)
+      throw new Error(DEACTIVATED_ERROR_MESSAGE)
     }
     // batch request support
     if (Array.isArray(req)) {

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -287,44 +287,33 @@ describe('basic tests', function () {
     })
   })
 
-  it('destroys engine and middlewares', function (done) {
-    const expectedError = new Error('Engine is deactivated; please initialize new engine.')
+  it('engine.destroy destroys engine', function (done) {
+    const expectedError = new Error('This engine is destroyed; please initialize a new engine.')
 
     const engine = new RpcEngine()
 
-    const middleware = function (_req, _res, _next, _end) {
-      console.log('foo')
-    }
-    middleware.destroyed = false
-    middleware.destroy = () => {
-      middleware.destroyed = true
-    }
-
-    engine.push(middleware)
-
-    assert.ok(engine.isActive(), 'engine should be active')
+    assert.ok(!engine.isDestroyed(), 'engine should not be destroyed')
 
     engine.destroy()
 
-    assert.ok(!engine.isActive(), 'engine should not be active')
-    assert.ok(middleware.destroyed, 'middleware should be destroyed')
+    assert.ok(engine.isDestroyed(), 'engine should be destroyed')
 
     assert.throws(
       () => engine.push(),
       expectedError,
-      'error should have expected message',
+      'engine.push should throw expected error',
     )
 
     assert.throws(
       () => engine.handle(),
       expectedError,
-      'error should have expected message',
+      'engine.handle should throw expected error',
     )
 
     // destroy is idempotent
     engine.destroy()
 
-    assert.ok(!engine.isActive(), 'engine should still not be active')
+    assert.ok(engine.isDestroyed(), 'engine should still be destroyed')
     done()
   })
 })

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -288,7 +288,7 @@ describe('basic tests', function () {
   })
 
   it('engine.destroy destroys engine', function (done) {
-    const expectedError = new Error('This engine is destroyed; please initialize a new engine.')
+    const expectedError = new Error('JsonRpcEngine: This engine is destroyed; please initialize a new engine.')
 
     const engine = new RpcEngine()
 
@@ -308,6 +308,12 @@ describe('basic tests', function () {
       () => engine.handle(),
       expectedError,
       'engine.handle should throw expected error',
+    )
+
+    assert.throws(
+      () => engine._handle(),
+      expectedError,
+      'engine._handle should throw expected error',
     )
 
     // destroy is idempotent

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -288,7 +288,7 @@ describe('basic tests', function () {
   })
 
   it('destroys engine and middlewares', function (done) {
-    const expectedErrorMessage = 'Engine is deactivated; please initialize new engine.'
+    const expectedError = new Error('Engine is deactivated; please initialize new engine.')
 
     const engine = new RpcEngine()
 
@@ -302,37 +302,29 @@ describe('basic tests', function () {
 
     engine.push(middleware)
 
-    assert(engine.isActive(), 'engine should be active')
+    assert.ok(engine.isActive(), 'engine should be active')
 
     engine.destroy()
 
-    assert(!engine.isActive(), 'engine should not be active')
-    assert(middleware.destroyed, 'middleware should be destroyed')
+    assert.ok(!engine.isActive(), 'engine should not be active')
+    assert.ok(middleware.destroyed, 'middleware should be destroyed')
 
-    try {
-      engine.push()
-    } catch (err) {
-      assert(err, 'engine.push should error')
-      assert.equal(
-        err.message, expectedErrorMessage,
-        'error should have expected message',
-      )
-    }
+    assert.throws(
+      () => engine.push(),
+      expectedError,
+      'error should have expected message',
+    )
 
-    try {
-      engine.handle()
-    } catch (err) {
-      assert(err, 'engine.handle should error')
-      assert.equal(
-        err.message, expectedErrorMessage,
-        'error should have expected message',
-      )
-    }
+    assert.throws(
+      () => engine.handle(),
+      expectedError,
+      'error should have expected message',
+    )
 
     // destroy is idempotent
     engine.destroy()
 
-    assert(!engine.isActive(), 'engine should still not be active')
+    assert.ok(!engine.isActive(), 'engine should still not be active')
     done()
   })
 })


### PR DESCRIPTION
Adds a `destroy` function to `JsonRpcEngine` which tears down it and its middlewares.

Motivated by [these lines in the extension](https://github.com/MetaMask/metamask-extension/blob/890bc25e2863162eb27b4c903357212c222ec904/app/scripts/metamask-controller.js#L1566-L1570), which this is designed to replace.