### PR TITLE
Use strict assert for tests

### DIFF
--- a/test/asMiddleware.spec.js
+++ b/test/asMiddleware.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { strict: assert } = require('assert')
 const RpcEngine = require('../src')
 const asMiddleware = require('../src/asMiddleware.js')
 

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { strict: assert } = require('assert')
 const RpcEngine = require('../src')
 
 describe('basic tests', function () {

--- a/test/createAsyncMiddleware.spec.js
+++ b/test/createAsyncMiddleware.spec.js
@@ -2,7 +2,7 @@
 /* eslint require-await: 0 */
 'use strict'
 
-const assert = require('assert')
+const { strict: assert } = require('assert')
 const RpcEngine = require('../src')
 const createAsyncMiddleware = require('../src/createAsyncMiddleware.js')
 

--- a/test/idRemapMiddleware.spec.js
+++ b/test/idRemapMiddleware.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { strict: assert } = require('assert')
 const RpcEngine = require('../src')
 const createIdRemapMiddleware = require('../src/idRemapMiddleware.js')
 

--- a/test/mergeMiddleware.spec.js
+++ b/test/mergeMiddleware.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { strict: assert } = require('assert')
 const RpcEngine = require('../src')
 const mergeMiddleware = require('../src/mergeMiddleware.js')
 


### PR DESCRIPTION
This PR updates the tests to use [the strict mode for `assert`](https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_strict_mode).

From the docs:

> When using the `strict mode`, any `assert` function will use the equality used in the strict function mode. So `assert.deepEqual()` will, for example, work the same as `assert.deepStrictEqual()`.