### PR TITLE
Delete .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-env"
-  ]
-}


### PR DESCRIPTION
This PR deletes the `.babelrc` file. From reading [the docs](https://babeljs.io/docs/en/config-files) I believe that this file has a lower precedence than the existing `babel.config.js` file.