### PR TITLE
Use async/await instead of async package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "lint:fix": "eslint . --ext js,json --fix",
     "build": "babel src --out-dir dist",
     "test": "mocha ./test",
+    "test:path": "mocha",
     "coverage": "nyc yarn test"
   },
   "dependencies": {
-    "async": "^2.0.1",
     "eth-json-rpc-errors": "^2.0.2",
     "promise-to-callback": "^1.0.0",
     "safe-event-emitter": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint . --ext js,json --fix",
     "build": "babel src --out-dir dist",
     "test": "mocha ./test",
-    "test:path": "mocha",
     "coverage": "nyc yarn test"
   },
   "dependencies": {

--- a/src/asMiddleware.js
+++ b/src/asMiddleware.js
@@ -2,18 +2,14 @@
 
 module.exports = function asMiddleware (engine) {
   return async function engineAsMiddleware (req, res, next, end) {
-    // engine._runMiddlewareDown(req, res)
-    //   .then(({ isComplete, returnHandlers }) => {
-
-    //   })
     const { isComplete, returnHandlers } = await engine._runMiddlewareDown(req, res)
 
     let err = null
 
     if (isComplete) {
       return runReturnHandlers()
-        .catch((_err) => {
-          err = _err
+        .catch((handlerError) => {
+          err = handlerError
         })
         .finally(() => {
           end(err)

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ module.exports = class RpcEngine extends SafeEventEmitter {
     }
 
     let err = null
+
     this._runMiddleware(req, res)
       .catch((middlewareError) => {
         err = middlewareError
@@ -139,7 +140,7 @@ module.exports = class RpcEngine extends SafeEventEmitter {
       }
     }
 
-    const returnHandlers = allReturnHandlers.filter(Boolean).reverse()
+    const returnHandlers = allReturnHandlers.reverse()
     return { isComplete, returnHandlers }
 
     // runs an individual middleware
@@ -157,13 +158,14 @@ module.exports = class RpcEngine extends SafeEventEmitter {
             end(res.error)
           } else {
             // add return handler
-            allReturnHandlers.push(returnHandler)
+            if (returnHandler) {
+              allReturnHandlers.push(returnHandler)
+            }
             resolve()
           }
         }
 
         function end (err) {
-          // if errored, set the error but dont pass to callback
           const anyError = err || (res && res.error)
           if (anyError) {
             res.error = serializeError(anyError)

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,13 +941,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async@^2.0.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
-  integrity sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==
-  dependencies:
-    lodash "^4.14.0"
-
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -2537,7 +2530,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash@^4.14.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
_Note:_ We should test this out with the extension and internal packages before merging and publishing.

Replaces the `async` NPM package with use of Promises and native `async`/`await` functionality.
Should, and must be, functionally equivalent.

Removing `async` will decrease this package's bundle size by ~73%: https://bundlephobia.com/result?p=json-rpc-engine@5.1.8