### PR TITLE
Use eth-rpc-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "coverage": "nyc yarn test"
   },
   "dependencies": {
-    "eth-json-rpc-errors": "^2.0.2",
+    "eth-rpc-errors": "^2.1.1",
     "promise-to-callback": "^1.0.0",
     "safe-event-emitter": "^1.0.1"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 
-import { IEthereumRpcError } from 'eth-json-rpc-errors/@types'
+import { IEthereumRpcError } from 'eth-rpc-errors/@types'
 
 /** A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0". */
 export type JsonRpcVersion = "2.0";

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@
 
 const SafeEventEmitter = require('safe-event-emitter')
 const {
-  serializeError, EthereumRpcError, ERROR_CODES,
-} = require('eth-json-rpc-errors')
+  serializeError,
+  EthereumRpcError,
+  ERROR_CODES,
+} = require('eth-rpc-errors')
 
 module.exports = class RpcEngine extends SafeEventEmitter {
   constructor () {
@@ -113,16 +115,12 @@ module.exports = class RpcEngine extends SafeEventEmitter {
     if (!('result' in res) && !('error' in res)) {
       const requestBody = JSON.stringify(req, null, 2)
       const message = `JsonRpcEngine: Response has no error or result for request:\n${requestBody}`
-      throw new EthereumRpcError(
-        ERROR_CODES.rpc.internal, message, req,
-      )
+      throw new EthereumRpcError(ERROR_CODES.rpc.internal, message, req)
     }
     if (!isComplete) {
       const requestBody = JSON.stringify(req, null, 2)
       const message = `JsonRpcEngine: Nothing ended request:\n${requestBody}`
-      throw new EthereumRpcError(
-        ERROR_CODES.rpc.internal, message, req,
-      )
+      throw new EthereumRpcError(ERROR_CODES.rpc.internal, message, req)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,10 +1635,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-eth-json-rpc-errors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
-  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
+eth-rpc-errors@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
+  integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
   dependencies:
     fast-safe-stringify "^2.0.6"
 


### PR DESCRIPTION
Use `eth-rpc-errors` instead of the deprecated `eth-json-rpc-errors` package. The packages are functionally equivalent as used in `json-rpc-engine`.