### PR TITLE
Fix asMiddleware implementation, add test cases

### DIFF
--- a/src/asMiddleware.js
+++ b/src/asMiddleware.js
@@ -3,30 +3,25 @@
 module.exports = function asMiddleware (engine) {
   return function engineAsMiddleware (req, res, next, end) {
 
-    let err = null
-
     engine._runMiddlewares(req, res)
       .then(async ({ isComplete, returnHandlers }) => {
+
         if (isComplete) {
-          return await runReturnHandlers()
+          await engine._runReturnHandlers(returnHandlers)
+          return end()
         }
 
-        return next(async (cb) => {
-          await runReturnHandlers()
-          cb()
-        })
-
-        async function runReturnHandlers () {
-          for (const handler of returnHandlers) {
-            await new Promise((resolve) => handler(resolve))
+        return next(async (handlerCallback) => {
+          try {
+            await engine._runReturnHandlers(returnHandlers)
+          } catch (err) {
+            return handlerCallback(err)
           }
-        }
+          handlerCallback()
+        })
       })
       .catch((error) => {
-        err = error
-      })
-      .finally(() => {
-        end(err)
+        end(error)
       })
   }
 }

--- a/src/asMiddleware.js
+++ b/src/asMiddleware.js
@@ -2,7 +2,6 @@
 
 module.exports = function asMiddleware (engine) {
   return function engineAsMiddleware (req, res, next, end) {
-
     engine._runMiddlewares(req, res)
       .then(async ({ isComplete, returnHandlers }) => {
 
@@ -17,7 +16,7 @@ module.exports = function asMiddleware (engine) {
           } catch (err) {
             return handlerCallback(err)
           }
-          handlerCallback()
+          return handlerCallback()
         })
       })
       .catch((error) => {

--- a/src/index.js
+++ b/src/index.js
@@ -99,11 +99,8 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   }
 
   async _processRequest (req, res) {
-
     const { isComplete, returnHandlers } = await this._runMiddlewares(req, res)
-
     this._checkForCompletion(req, res, isComplete)
-
     await this._runReturnHandlers(returnHandlers)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,11 @@ module.exports = class RpcEngine extends SafeEventEmitter {
 
     this._checkForCompletion(req, res, isComplete)
 
-    for (const handler of returnHandlers) {
+    await this._runReturnHandlers(returnHandlers)
+  }
+
+  async _runReturnHandlers (handlers) {
+    for (const handler of handlers) {
       await new Promise((resolve, reject) => {
         handler((err) => (err ? reject(err) : resolve()))
       })


### PR DESCRIPTION
The re-implementation of `asMiddleware` in #45 was not quite correct, which was discovered during additional testing.

Most importantly, it did not handle errors thrown in return handlers. This has been addressed by re-encapsulating the application of return handlers in a function on the `RpcEngine` class, and correcting the use of the `end` and return handler callbacks in `asMiddleware`.

Test cases have been added.