### PR TITLE
Rationalize _promiseHandle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,16 +49,11 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   }
 
   _promiseHandle (req) {
-    return new Promise((resolve, reject) => {
-      this._handle(req, (err, res) => {
-        if (res) {
-          resolve(res)
-        } else {
-          reject(err || new EthereumRpcError(
-            ERROR_CODES.rpc.internal,
-            'JsonRpcEngine: Request handler returned neither error nor response.',
-          ))
-        }
+    return new Promise((resolve) => {
+      this._handle(req, (_err, res) => {
+        // there will always be a response, and it will always have any error
+        // that is caught and propagated
+        resolve(res)
       })
     })
   }


### PR DESCRIPTION
`_promiseHandle` included a pointless `if`-condition, that would only ever proceed down one branch.

The `if`-statement and its `else` clause have been removed.