### PR TITLE
Add async handle signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ Requests are handled asynchronously, stepping down the stack until complete.
 ```js
 let request = { id: 1, jsonrpc: '2.0', method: 'hello' }
 
-engine.handle(request, function(err, res){
-  // do something with res.result
+engine.handle(request, function(err, response){
+  // do something with response.result
 })
+
+// there is also a Promise signature
+const response = await engine.handle(request)
 ```
 
 Middleware have direct access to the request and response objects.


### PR DESCRIPTION
- Adds an `async` signature for `RpcEngine.handle`, so that you can do e.g. `const result = await engine.handle(request)`.
  - Works for single and batch requests. Callback signature works the same as before.
- Tests will be added in #52 
- Closes #31, which accomplished the same thing, but was never merged.