### PR TITLE
Rename _runMiddlewares to _runAllMiddleware

### DIFF
--- a/src/asMiddleware.js
+++ b/src/asMiddleware.js
@@ -2,7 +2,7 @@
 
 module.exports = function asMiddleware (engine) {
   return function engineAsMiddleware (req, res, next, end) {
-    engine._runMiddlewares(req, res)
+    engine._runAllMiddleware(req, res)
       .then(async ({ isComplete, returnHandlers }) => {
 
         if (isComplete) {

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   }
 
   async _processRequest (req, res) {
-    const { isComplete, returnHandlers } = await this._runMiddlewares(req, res)
+    const { isComplete, returnHandlers } = await this._runAllMiddleware(req, res)
     this._checkForCompletion(req, res, isComplete)
     await this._runReturnHandlers(returnHandlers)
   }
@@ -126,7 +126,7 @@ module.exports = class RpcEngine extends SafeEventEmitter {
   }
 
   // walks down stack of middleware
-  async _runMiddlewares (req, res) {
+  async _runAllMiddleware (req, res) {
 
     const returnHandlers = []
     // flag for early return


### PR DESCRIPTION
In line with treating the word "middleware" as plural and "middlewares" as the typo that it is, this PR renames `_runMiddlewares` to `_runAllMiddleware`.