### PR TITLE
Correctly characterize async/await changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These dependencies were used internally for middleware flow control.
   They have been replaced with Promises and native `async`/`await`, which means that some operations are _no longer_ eagerly executed.
   This change may affect consumers that depend on the eager execution of middleware _during_ middleware execution, _outside of_ middleware functions and request handlers.
+    - In general, it is a bad practice to work with state that depends on middleware execution, while the middleware are executing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove `async` and `promise-to-callback` dependencies
-  - These dependencies were used internally for asynchronous control flow.
-  They have been replaced with Promises and native `async`/`await`.
-  This has made middleware execution faster, and may affect consumers that rely on middleware timing, advertently or not.
+  - These dependencies were used internally for middleware flow control.
+  They have been replaced with Promises and native `async`/`await`, which means that some operations are _no longer_ eagerly executed.
+  This change may affect consumers that depend on the eager execution of middleware _during_ middleware execution, _outside of_ middleware functions and request handlers.


### PR DESCRIPTION
The changelog mischaracterized what had changed about middleware execution as a result of #45. This PR correctly characterizes the changes.