### PR TITLE
Add runtime typecheck for request objects and return handlers, refactor _handle

### DIFF
--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -8,7 +8,7 @@ export type Json =
   | number
   | string
   | null
-  | { [property: string]: Json}
+  | { [property: string]: Json }
   | Json[];
 
 /**
@@ -123,10 +123,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   handle<T, U>(
     request: JsonRpcRequest<T>,
-    callback: (
-      error: unknown,
-      response: JsonRpcResponse<U>
-    ) => void
+    callback: (error: unknown, response: JsonRpcResponse<U>) => void,
   ): void;
 
   /**
@@ -138,10 +135,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   handle<T, U>(
     requests: JsonRpcRequest<T>[],
-    callback: (
-      error: unknown,
-      responses: JsonRpcResponse<U>[]
-    ) => void
+    callback: (error: unknown, responses: JsonRpcResponse<U>[]) => void,
   ): void;
 
   /**
@@ -160,9 +154,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    * @returns A promise that resolves with the array of responses, or rejects
    * with an error.
    */
-  handle<T, U>(
-    requests: JsonRpcRequest<T>[]
-  ): Promise<JsonRpcResponse<U>[]>;
+  handle<T, U>(requests: JsonRpcRequest<T>[]): Promise<JsonRpcResponse<U>[]>;
 
   handle(req: unknown, cb?: any) {
     if (cb && typeof cb !== 'function') {
@@ -241,10 +233,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
 
   private async _handle(
     callerReq: JsonRpcRequest<unknown>,
-    cb: (
-      error: unknown,
-      response: JsonRpcResponse<unknown>
-    ) => void,
+    cb: (error: unknown, response: JsonRpcResponse<unknown>) => void,
   ): Promise<void> {
     if (
       !callerReq ||
@@ -369,9 +358,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     returnHandlers: JsonRpcEngineReturnHandler[],
   ): Promise<boolean> {
     return new Promise((resolve) => {
-      const end: JsonRpcEngineEndCallback = (
-        err?: unknown,
-      ) => {
+      const end: JsonRpcEngineEndCallback = (err?: unknown) => {
         const error = err || res.error;
         if (error) {
           res.error = serializeError(error);

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -247,6 +247,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
       );
       return cb(error, { id: undefined, jsonrpc: '2.0', error });
     }
+
     if (typeof callerReq.method !== 'string') {
       const error = new EthereumRpcError(
         errorCodes.rpc.invalidRequest,

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -247,6 +247,14 @@ export class JsonRpcEngine extends SafeEventEmitter {
       );
       return cb(error, { id: undefined, jsonrpc: '2.0', error });
     }
+    if (typeof callerReq.method !== 'string') {
+      const error = new EthereumRpcError(
+        errorCodes.rpc.invalidRequest,
+        `Must specify a string method. Received: ${callerReq.method}`,
+        { request: callerReq },
+      );
+      return cb(error, { id: callerReq.id, jsonrpc: '2.0', error });
+    }
 
     const req: JsonRpcRequest<unknown> = { ...callerReq };
     const res: InternalJsonRpcResponse = {

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -94,6 +94,10 @@ type InternalMiddleware = (
   end: JsonRpcEngineEndCallback
 ) => void;
 
+/**
+ * A JSON-RPC request and response processor.
+ * Give it a stack of middleware, pass it requests, and get back responses.
+ */
 export class JsonRpcEngine extends SafeEventEmitter {
   private _middleware: InternalMiddleware[];
 
@@ -102,10 +106,21 @@ export class JsonRpcEngine extends SafeEventEmitter {
     this._middleware = [];
   }
 
+  /**
+   * Add a middleware function to the engine's middleware stack.
+   *
+   * @param middleware - The middleware function to add.
+   */
   push<T, U>(middleware: JsonRpcMiddleware<T, U>): void {
     this._middleware.push(middleware as InternalMiddleware);
   }
 
+  /**
+   * Handle a JSON-RPC request, and return a response.
+   *
+   * @param request - The request to handle.
+   * @param callback - An error-first callback that will receive the response.
+   */
   handle<T, U>(
     request: JsonRpcRequest<T>,
     callback: (
@@ -114,6 +129,13 @@ export class JsonRpcEngine extends SafeEventEmitter {
     ) => void
   ): void;
 
+  /**
+   * Handle an array of JSON-RPC requests, and return an array of responses.
+   *
+   * @param request - The requests to handle.
+   * @param callback - An error-first callback that will receive the array of
+   * responses.
+   */
   handle<T, U>(
     requests: JsonRpcRequest<T>[],
     callback: (
@@ -122,8 +144,22 @@ export class JsonRpcEngine extends SafeEventEmitter {
     ) => void
   ): void;
 
+  /**
+   * Handle a JSON-RPC request, and return a response.
+   *
+   * @param request - The request to handle.
+   * @returns A promise that resolves with the response, or rejects with an
+   * error.
+   */
   handle<T, U>(request: JsonRpcRequest<T>): Promise<JsonRpcResponse<U>>;
 
+  /**
+   * Handle an array of JSON-RPC requests, and return an array of responses.
+   *
+   * @param request - The requests to handle.
+   * @returns A promise that resolves with the array of responses, or rejects
+   * with an error.
+   */
   handle<T, U>(
     requests: JsonRpcRequest<T>[]
   ): Promise<JsonRpcResponse<U>[]>;
@@ -149,6 +185,12 @@ export class JsonRpcEngine extends SafeEventEmitter {
     return this._promiseHandle(req as JsonRpcRequest<unknown>);
   }
 
+  /**
+   * Returns this engine as a middleware function that can be pushed to other
+   * engines.
+   *
+   * @returns This engine as a middleware function.
+   */
   asMiddleware(): JsonRpcMiddleware<unknown, unknown> {
     return (req, res, next, end) => {
       this._runAllMiddleware(req, res)

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -204,6 +204,19 @@ export class JsonRpcEngine extends SafeEventEmitter {
       response: JsonRpcResponse<unknown>
     ) => void,
   ): Promise<void> {
+    if (
+      !callerReq ||
+      Array.isArray(callerReq) ||
+      typeof callerReq !== 'object'
+    ) {
+      const error = new EthereumRpcError(
+        errorCodes.rpc.invalidRequest,
+        `Requests must be plain objects. Received: ${typeof callerReq}`,
+        { request: callerReq },
+      );
+      return cb(error, { id: undefined, jsonrpc: '2.0', error });
+    }
+
     const req: JsonRpcRequest<unknown> = { ...callerReq };
     const res: InternalJsonRpcResponse = {
       id: req.id,

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -209,6 +209,29 @@ describe('JsonRpcEngine', function () {
     });
   });
 
+  it('erroring middleware test: non-function passsed to next()', function (done) {
+    const engine = new JsonRpcEngine();
+
+    engine.push(function (_req, _res, next, _end) {
+      next(true);
+    });
+
+    const payload = { id: 1, jsonrpc: '2.0', method: 'hello' };
+
+    engine.handle(payload, function (err, res) {
+      assert.ok(err, 'should error');
+      assert.ok(res, 'should have response');
+      assert.ok(res.error, 'should have error on response');
+      assert.equal(res.error.code, -32603, 'should have expected error');
+      assert.ok(
+        res.error.message.startsWith('JsonRpcEngine: "next" return handlers must be functions.'),
+        'should have expected error',
+      );
+      assert.ok(!res.result, 'should not have result on response');
+      done();
+    });
+  });
+
   it('empty middleware test', function (done) {
     const engine = new JsonRpcEngine();
 

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -17,13 +17,24 @@ describe('JsonRpcEngine', function () {
 
   it('handle: returns error for invalid request parameter', async function () {
     const engine = new JsonRpcEngine();
-    const response1 = await engine.handle(null);
-    assert.equal(response1.error.code, -32600, 'should have expected error');
-    assert.equal(response1.result, undefined, 'should have no results');
+    let response = await engine.handle(null);
+    assert.equal(response.error.code, -32600, 'should have expected error');
+    assert.equal(response.result, undefined, 'should have no results');
 
-    const response2 = await engine.handle(true);
-    assert.equal(response2.error.code, -32600, 'should have expected error');
-    assert.equal(response2.result, undefined, 'should have no results');
+    response = await engine.handle(true);
+    assert.equal(response.error.code, -32600, 'should have expected error');
+    assert.equal(response.result, undefined, 'should have no results');
+  });
+
+  it('handle: returns error for invalid request method', async function () {
+    const engine = new JsonRpcEngine();
+    let response = await engine.handle({ method: null });
+    assert.equal(response.error.code, -32600, 'should have expected error');
+    assert.equal(response.result, undefined, 'should have no results');
+
+    response = await engine.handle({ method: true });
+    assert.equal(response.error.code, -32600, 'should have expected error');
+    assert.equal(response.result, undefined, 'should have no results');
   });
 
   it('handle: basic middleware test 1', function (done) {


### PR DESCRIPTION
- Reject requests if:
  - They are not plain objects
  - `request.method` is not a `string`
  - `next()` is called with a non-function parameter during processing
- Refactor internal method `_handle` to be async (stack traces may improve somewhat)
- Add docstrings for public methods
- Fix some formatting issues