### PR TITLE
Refactor internal error handling

### DIFF
--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -84,22 +84,14 @@ export type JsonRpcMiddleware<T, U> = (
 interface InternalJsonRpcResponse extends JsonRpcResponseBase {
   result?: unknown;
   error?: Error | JsonRpcError;
-  _originalError?: unknown;
 }
-
-type InternalMiddleware = (
-  req: JsonRpcRequest<unknown>,
-  res: InternalJsonRpcResponse,
-  next: JsonRpcEngineNextCallback,
-  end: JsonRpcEngineEndCallback
-) => void;
 
 /**
  * A JSON-RPC request and response processor.
  * Give it a stack of middleware, pass it requests, and get back responses.
  */
 export class JsonRpcEngine extends SafeEventEmitter {
-  private _middleware: InternalMiddleware[];
+  private _middleware: JsonRpcMiddleware<unknown, unknown>[];
 
   constructor() {
     super();
@@ -112,7 +104,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    * @param middleware - The middleware function to add.
    */
   push<T, U>(middleware: JsonRpcMiddleware<T, U>): void {
-    this._middleware.push(middleware as InternalMiddleware);
+    this._middleware.push(middleware as JsonRpcMiddleware<unknown, unknown>);
   }
 
   /**
@@ -185,22 +177,24 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   asMiddleware(): JsonRpcMiddleware<unknown, unknown> {
     return (req, res, next, end) => {
-      this._runAllMiddleware(req, res)
-        .then(async ({ isComplete, returnHandlers }) => {
-          if (isComplete) {
-            await this._runReturnHandlers(returnHandlers);
-            return end();
-          }
-
-          return next(async (handlerCallback) => {
-            try {
-              await this._runReturnHandlers(returnHandlers);
-            } catch (error) {
-              return handlerCallback(error);
+      JsonRpcEngine._runAllMiddleware(req, res, this._middleware)
+        .then(
+          async ([middlewareError, isComplete, returnHandlers]) => {
+            if (isComplete) {
+              await JsonRpcEngine._runReturnHandlers(returnHandlers);
+              return end(middlewareError as JsonRpcEngineCallbackError);
             }
-            return handlerCallback();
-          });
-        })
+
+            return next(async (handlerCallback) => {
+              try {
+                await JsonRpcEngine._runReturnHandlers(returnHandlers);
+              } catch (error) {
+                return handlerCallback(error);
+              }
+              return handlerCallback();
+            });
+          },
+        )
         .catch((error) => {
           end(error);
         });
@@ -251,7 +245,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     if (typeof callerReq.method !== 'string') {
       const error = new EthereumRpcError(
         errorCodes.rpc.invalidRequest,
-        `Must specify a string method. Received: ${callerReq.method}`,
+        `Must specify a string method. Received: ${typeof callerReq.method}`,
         { request: callerReq },
       );
       return cb(error, { id: callerReq.id, jsonrpc: '2.0', error });
@@ -262,21 +256,15 @@ export class JsonRpcEngine extends SafeEventEmitter {
       id: req.id,
       jsonrpc: req.jsonrpc,
     };
-
-    let processingError: JsonRpcEngineCallbackError = null;
+    let error: JsonRpcEngineCallbackError = null;
 
     try {
       await this._processRequest(req, res);
-    } catch (error) {
-      // either from return handlers or something unexpected
-      processingError = error;
+    } catch (_error) {
+      // A request handler error, a re-thrown middleware error, or something
+      // unexpected.
+      error = _error;
     }
-
-    // Preserve unserialized error, if any, for use in callback
-    const responseError = res._originalError;
-    delete res._originalError;
-
-    const error = responseError || processingError || null;
 
     if (error) {
       // Ensure no result is present on an errored response
@@ -293,62 +281,46 @@ export class JsonRpcEngine extends SafeEventEmitter {
     req: JsonRpcRequest<unknown>,
     res: InternalJsonRpcResponse,
   ): Promise<void> {
-    const { isComplete, returnHandlers } = await this._runAllMiddleware(
-      req,
-      res,
-    );
-    this._checkForCompletion(req, res, isComplete);
-    await this._runReturnHandlers(returnHandlers);
-  }
+    const [
+      error,
+      isComplete,
+      returnHandlers,
+    ] = await JsonRpcEngine._runAllMiddleware(req, res, this._middleware);
 
-  private async _runReturnHandlers(
-    handlers: JsonRpcEngineReturnHandler[],
-  ): Promise<void> {
-    for (const handler of handlers) {
-      await new Promise((resolve, reject) => {
-        handler((err) => (err ? reject(err) : resolve()));
-      });
-    }
-  }
+    // Throw if "end" was not called, or if the response has neither a result
+    // nor an error.
+    JsonRpcEngine._checkForCompletion(req, res, isComplete);
 
-  private _checkForCompletion(
-    req: JsonRpcRequest<unknown>,
-    res: InternalJsonRpcResponse,
-    isComplete: boolean,
-  ): void {
-    if (!('result' in res) && !('error' in res)) {
-      throw new EthereumRpcError(
-        errorCodes.rpc.internal,
-        `JsonRpcEngine: Response has no error or result for request:\n${jsonify(req)}`,
-        { request: req },
-      );
-    }
-    if (!isComplete) {
-      throw new EthereumRpcError(
-        errorCodes.rpc.internal,
-        `JsonRpcEngine: Nothing ended request:\n${jsonify(req)}`,
-        { request: req },
-      );
+    // The return handlers should run even if an error was encountered during
+    // middleware processing.
+    await JsonRpcEngine._runReturnHandlers(returnHandlers);
+
+    // Now we re-throw the middleware processing error, if any, to catch it
+    // further up the call chain.
+    if (error) {
+      throw error;
     }
   }
 
   /**
    * Walks down internal stack of middleware.
    */
-  private async _runAllMiddleware(
+  private static async _runAllMiddleware(
     req: JsonRpcRequest<unknown>,
     res: InternalJsonRpcResponse,
-  ): Promise<{
-      isComplete: boolean;
-      returnHandlers: JsonRpcEngineReturnHandler[];
-    }> {
+    middlewareStack: JsonRpcMiddleware<unknown, unknown>[],
+  ): Promise<[
+      unknown, // error
+      boolean, // isComplete
+      JsonRpcEngineReturnHandler[],
+    ]> {
     const returnHandlers: JsonRpcEngineReturnHandler[] = [];
-    // Flag for early return
+    let error = null;
     let isComplete = false;
 
     // Go down stack of middleware, call and collect optional returnHandlers
-    for (const middleware of this._middleware) {
-      isComplete = await JsonRpcEngine._runMiddleware(
+    for (const middleware of middlewareStack) {
+      [error, isComplete] = await JsonRpcEngine._runMiddleware(
         req,
         res,
         middleware,
@@ -358,27 +330,28 @@ export class JsonRpcEngine extends SafeEventEmitter {
         break;
       }
     }
-    return { isComplete, returnHandlers: returnHandlers.reverse() };
+    return [error, isComplete, returnHandlers.reverse()];
   }
 
   /**
    * Runs an individual middleware.
+   * @returns An array of a boolean indicating whether the request should end,
+   * and any error encountered during request processing.
    */
   private static _runMiddleware(
     req: JsonRpcRequest<unknown>,
     res: InternalJsonRpcResponse,
-    middleware: InternalMiddleware,
+    middleware: JsonRpcMiddleware<unknown, unknown>,
     returnHandlers: JsonRpcEngineReturnHandler[],
-  ): Promise<boolean> {
+  ): Promise<[unknown, boolean]> {
     return new Promise((resolve) => {
       const end: JsonRpcEngineEndCallback = (err?: unknown) => {
         const error = err || res.error;
         if (error) {
           res.error = serializeError(error);
-          res._originalError = error;
         }
         // True indicates that the request should end
-        resolve(true);
+        resolve([error, true]);
       };
 
       const next: JsonRpcEngineNextCallback = (
@@ -400,16 +373,47 @@ export class JsonRpcEngine extends SafeEventEmitter {
           }
 
           // False indicates that the request should not end
-          resolve(false);
+          resolve([null, false]);
         }
       };
 
       try {
-        middleware(req, res, next, end);
+        middleware(req, res as JsonRpcResponse<unknown>, next, end);
       } catch (error) {
         end(error);
       }
     });
+  }
+
+  private static async _runReturnHandlers(
+    handlers: JsonRpcEngineReturnHandler[],
+  ): Promise<void> {
+    for (const handler of handlers) {
+      await new Promise((resolve, reject) => {
+        handler((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  }
+
+  private static _checkForCompletion(
+    req: JsonRpcRequest<unknown>,
+    res: InternalJsonRpcResponse,
+    isComplete: boolean,
+  ): void {
+    if (!('result' in res) && !('error' in res)) {
+      throw new EthereumRpcError(
+        errorCodes.rpc.internal,
+        `JsonRpcEngine: Response has no error or result for request:\n${jsonify(req)}`,
+        { request: req },
+      );
+    }
+    if (!isComplete) {
+      throw new EthereumRpcError(
+        errorCodes.rpc.internal,
+        `JsonRpcEngine: Nothing ended request:\n${jsonify(req)}`,
+        { request: req },
+      );
+    }
   }
 }
 

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -201,6 +201,9 @@ export class JsonRpcEngine extends SafeEventEmitter {
     };
   }
 
+  /**
+   * Like _handle, but for batch requests.
+   */
   private async _handleBatch(
     reqs: JsonRpcRequest<unknown>[],
   ): Promise<JsonRpcResponse<unknown>[]> {
@@ -213,6 +216,9 @@ export class JsonRpcEngine extends SafeEventEmitter {
     );
   }
 
+  /**
+   * A promise-wrapped _handle.
+   */
   private _promiseHandle(
     req: JsonRpcRequest<unknown>,
   ): Promise<JsonRpcResponse<unknown>> {
@@ -225,6 +231,12 @@ export class JsonRpcEngine extends SafeEventEmitter {
     });
   }
 
+  /**
+   * Ensures that the request object is valid, processes it, and passes any
+   * error and the response object to the given callback.
+   *
+   * Does not reject.
+   */
   private async _handle(
     callerReq: JsonRpcRequest<unknown>,
     cb: (error: unknown, response: JsonRpcResponse<unknown>) => void,
@@ -277,6 +289,11 @@ export class JsonRpcEngine extends SafeEventEmitter {
     return cb(error, res as JsonRpcResponse<unknown>);
   }
 
+  /**
+   * For the given request and response, runs all middleware and their return
+   * handlers, if any, and ensures that internal request processing semantics
+   * are satisfied.
+   */
   private async _processRequest(
     req: JsonRpcRequest<unknown>,
     res: InternalJsonRpcResponse,
@@ -303,7 +320,11 @@ export class JsonRpcEngine extends SafeEventEmitter {
   }
 
   /**
-   * Walks down internal stack of middleware.
+   * Serially executes the given stack of middleware.
+   *
+   * @returns An array of any error encountered during middleware execution,
+   * a boolean indicating whether the request was completed, and an array of
+   * middleware-defined return handlers.
    */
   private static async _runAllMiddleware(
     req: JsonRpcRequest<unknown>,
@@ -335,8 +356,9 @@ export class JsonRpcEngine extends SafeEventEmitter {
 
   /**
    * Runs an individual middleware.
-   * @returns An array of a boolean indicating whether the request should end,
-   * and any error encountered during request processing.
+   *
+   * @returns An array of any error encountered during middleware exection,
+   * and a boolean indicating whether the request should end.
    */
   private static _runMiddleware(
     req: JsonRpcRequest<unknown>,
@@ -385,6 +407,10 @@ export class JsonRpcEngine extends SafeEventEmitter {
     });
   }
 
+  /**
+   * Serially executes array of return handlers. The request and response are
+   * assumed to be in their scope.
+   */
   private static async _runReturnHandlers(
     handlers: JsonRpcEngineReturnHandler[],
   ): Promise<void> {
@@ -395,6 +421,10 @@ export class JsonRpcEngine extends SafeEventEmitter {
     }
   }
 
+  /**
+   * Throws an error if the response has neither a result nor an error, or if
+   * the "isComplete" flag is falsy.
+   */
   private static _checkForCompletion(
     req: JsonRpcRequest<unknown>,
     res: InternalJsonRpcResponse,


### PR DESCRIPTION
- Remove `InternalMiddleware` type
- Remove `_originalError` property, pass up errors encountered during middleware processing by returning them
- Convert some internal methods to `static`