### PR TITLE
Add pending response type

### DIFF
--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -60,6 +60,11 @@ export interface JsonRpcFailure extends JsonRpcResponseBase {
 
 export type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcFailure;
 
+export interface PendingJsonRpcResponse<T> extends JsonRpcResponseBase {
+  result?: T;
+  error?: Error | JsonRpcError;
+}
+
 export type JsonRpcEngineCallbackError = Error | JsonRpcError | null;
 
 export type JsonRpcEngineReturnHandler = (
@@ -76,15 +81,10 @@ export type JsonRpcEngineEndCallback = (
 
 export type JsonRpcMiddleware<T, U> = (
   req: JsonRpcRequest<T>,
-  res: JsonRpcResponse<U>,
+  res: PendingJsonRpcResponse<U>,
   next: JsonRpcEngineNextCallback,
   end: JsonRpcEngineEndCallback
 ) => void;
-
-interface InternalJsonRpcResponse extends JsonRpcResponseBase {
-  result?: unknown;
-  error?: Error | JsonRpcError;
-}
 
 /**
  * A JSON-RPC request and response processor.
@@ -264,7 +264,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     }
 
     const req: JsonRpcRequest<unknown> = { ...callerReq };
-    const res: InternalJsonRpcResponse = {
+    const res: PendingJsonRpcResponse<unknown> = {
       id: req.id,
       jsonrpc: req.jsonrpc,
     };
@@ -296,7 +296,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   private async _processRequest(
     req: JsonRpcRequest<unknown>,
-    res: InternalJsonRpcResponse,
+    res: PendingJsonRpcResponse<unknown>,
   ): Promise<void> {
     const [
       error,
@@ -328,7 +328,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   private static async _runAllMiddleware(
     req: JsonRpcRequest<unknown>,
-    res: InternalJsonRpcResponse,
+    res: PendingJsonRpcResponse<unknown>,
     middlewareStack: JsonRpcMiddleware<unknown, unknown>[],
   ): Promise<[
       unknown, // error
@@ -362,7 +362,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   private static _runMiddleware(
     req: JsonRpcRequest<unknown>,
-    res: InternalJsonRpcResponse,
+    res: PendingJsonRpcResponse<unknown>,
     middleware: JsonRpcMiddleware<unknown, unknown>,
     returnHandlers: JsonRpcEngineReturnHandler[],
   ): Promise<[unknown, boolean]> {
@@ -400,7 +400,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
       };
 
       try {
-        middleware(req, res as JsonRpcResponse<unknown>, next, end);
+        middleware(req, res, next, end);
       } catch (error) {
         end(error);
       }
@@ -427,7 +427,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
    */
   private static _checkForCompletion(
     req: JsonRpcRequest<unknown>,
-    res: InternalJsonRpcResponse,
+    res: PendingJsonRpcResponse<unknown>,
     isComplete: boolean,
   ): void {
     if (!('result' in res) && !('error' in res)) {

--- a/src/createAsyncMiddleware.ts
+++ b/src/createAsyncMiddleware.ts
@@ -1,14 +1,14 @@
 import {
   JsonRpcMiddleware,
   JsonRpcRequest,
-  JsonRpcResponse,
+  PendingJsonRpcResponse,
 } from './JsonRpcEngine';
 
 export type AsyncJsonRpcEngineNextCallback = () => Promise<void>;
 
 export type AsyncJsonrpcMiddleware<T, U> = (
   req: JsonRpcRequest<T>,
-  res: JsonRpcResponse<U>,
+  res: PendingJsonRpcResponse<U>,
   next: AsyncJsonRpcEngineNextCallback
 ) => Promise<void>;
 


### PR DESCRIPTION
Using the `JsonRpcResponse` type in middleware became really painful when implementing middleware. When a response object is in a middleware, it's not a finished response; it's pending. If you use `JsonRpcResponse`, you have to re-cast the response object in order to set either `error` or `result`. That sucks.

To fix this sorry state of affairs, this PR replaces the `InternalJsonRpcResponse` interface with an exported, genericized `PendingJsonRpcResponse` interface. This could be abused in terms of type safety by setting both `result` and `error` on a response, but `result` will be deleted if `error` is present.