### PR TITLE
createScaffoldMiddleware ScaffoldMiddlewareHandler annotate any instead of unknown

### DIFF
--- a/src/createScaffoldMiddleware.ts
+++ b/src/createScaffoldMiddleware.ts
@@ -3,8 +3,8 @@ import { Json, JsonRpcMiddleware, JsonRpcSuccess } from './JsonRpcEngine';
 type ScaffoldMiddlewareHandler<T, U> = JsonRpcMiddleware<T, U> | Json;
 
 export function createScaffoldMiddleware(handlers: {
-  [methodName: string]: ScaffoldMiddlewareHandler<unknown, unknown>;
-}): JsonRpcMiddleware<unknown, unknown> {
+  [methodName: string]: ScaffoldMiddlewareHandler<any, any>;
+}): JsonRpcMiddleware<any, any> {
   return (req, res, next, end) => {
     const handler = handlers[req.method];
     // if no handler, return


### PR DESCRIPTION
`unknown` make annotate difficult

eg

```typescript
export function createMiddleware() {
  return createScaffoldMiddleware({
    [GET_ACCOUNT]: createAsyncMiddleware(getAccount), // 'unknown will throw annotate error'
  });
}


const getAccount: AsyncJsonrpcMiddleware<string, IAccount> = async function (req, res) {

};
```