### PR TITLE
resolve() function argument was missing in Promise definition

### DIFF
--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -447,7 +447,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     handlers: JsonRpcEngineReturnHandler[],
   ): Promise<void> {
     for (const handler of handlers) {
-      await new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         handler((err) => (err ? reject(err) : resolve()));
       });
     }

--- a/src/createAsyncMiddleware.ts
+++ b/src/createAsyncMiddleware.ts
@@ -38,7 +38,7 @@ export function createAsyncMiddleware<T, U>(
     // nextPromise is the key to the implementation
     // it is resolved by the return handler passed to the
     // "next" function
-    let resolveNextPromise: () => void;
+    let resolveNextPromise: (value?: unknown) => void;
     const nextPromise = new Promise((resolve) => {
       resolveNextPromise = resolve;
     });

--- a/src/createAsyncMiddleware.ts
+++ b/src/createAsyncMiddleware.ts
@@ -38,8 +38,8 @@ export function createAsyncMiddleware<T, U>(
     // nextPromise is the key to the implementation
     // it is resolved by the return handler passed to the
     // "next" function
-    let resolveNextPromise: (value?: unknown) => void;
-    const nextPromise = new Promise((resolve) => {
+    let resolveNextPromise: () => void;
+    const nextPromise = new Promise<void>((resolve) => {
       resolveNextPromise = resolve;
     });
 

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const { strict: assert } = require('assert');
-const { JsonRpcEngine } = require('../dist');
 const { stub } = require('sinon');
+const { JsonRpcEngine } = require('../dist');
 
 describe('JsonRpcEngine', function () {
   it('handle: throws on truthy, non-function callback', function () {

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -2,8 +2,8 @@
 'use strict';
 
 const { strict: assert } = require('assert');
-const { stub } = require('sinon');
 const { JsonRpcEngine } = require('../dist');
+const { stub } = require('sinon');
 
 describe('JsonRpcEngine', function () {
   it('handle: throws on truthy, non-function callback', function () {


### PR DESCRIPTION
* Issue is solved by typecasting the Promise to `Promise<void>` so that the `value` argument for `resolve()` will be set to `void`.
