### PR TITLE
WIP: Improve middleware errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Middleware functions **must** return a falsy value or a function.
 If anything else is returned, the request will end with an error.
 
 If a middleware calls `end()`, its return value will be ignored.
+The `end()` callback **must not** be passed a value.
 
 Engines can be nested by converting them to middleware using `JsonRpcEngine.asMiddleware()`:
 
@@ -81,34 +82,14 @@ engine.push(subengine.asMiddleware());
 
 ### Error Handling
 
-Errors should be handled by throwing inside middleware functions.
+Errors must be handled by throwing them inside middleware functions.
+A thrown error will immediately end middleware processing,
+and return a response object with an `error` but no `result`.
 
-For backwards compatibility, you can also pass an error to the `end` callback,
-or set the error on the response object, and then return or call `end`.
+Errors assigned directly to `response.error` will be overwritten.
+Non-`Error` values thrown inside middleware will be added under the `data` property of a new `Error`,
+which will be used as the response `error`.
 
-Errors always take precedent over results.
-If an error is detected, the response's `result` property will be deleted.
-
-All of the following examples are equivalent.
-It does not matter of the middleware function is synchronous or asynchronous.
-
-```js
-// Throwing is preferred.
-engine.push(function (req, res, end) {
-  throw new Error();
-});
-
-// For backwards compatibility, you can also do this:
-engine.push(function (req, res, end) {
-  end(new Error());
-});
-
-engine.push(function (req, res, end) {
-  res.error = new Error();
-  end();
-});
-
-engine.push(function (req, res, end) {
-  res.error = new Error();
-});
-```
+The `error` property of a response object returned by this package will always
+be a valid [JSON-RPC error](https://www.jsonrpc.org/specification#error_object), if present.
+These error values are plain objects, without `stack` properties.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ engine.push(function (req, res, end) {
 });
 ```
 
+`end()` **must** be called once during middleware processing, or an internal error will be returned.
+
 Middleware functions can be `async`:
 
 ```js

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -524,7 +524,6 @@ export class JsonRpcEngine extends SafeEventEmitter {
     res: PendingJsonRpcResponse<unknown>,
     error: unknown,
   ) {
-    /* eslint-disable require-atomic-updates */
     if (error instanceof Error) {
       if (error instanceof EthereumRpcError) {
         res.error = error;
@@ -543,7 +542,6 @@ export class JsonRpcEngine extends SafeEventEmitter {
         { request: req, thrownValue: error },
       );
     }
-    /* eslint-enable require-atomic-updates */
   }
 }
 

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -514,8 +514,9 @@ export class JsonRpcEngine extends SafeEventEmitter {
   }
 
   /**
-   * Processes an error thrown during middleware processing, and coerces it into
-   * a valid JSON-RPC error.
+   * Processes an error thrown during middleware processing, coerces it into
+   * a valid JSON-RPC error, and assigns it to the response.
+   * Attempts to preserve as many properties of the original error as possible.
    *
    * Must only be called in response to an error thrown by a consumer middleware.
    */

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -489,7 +489,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     req: JsonRpcRequest<unknown>,
     res: PendingJsonRpcResponse<unknown>,
     endArg: unknown,
-  ) {
+  ): void {
     if (endArg instanceof Error) {
       throw new EthereumRpcError(
         errorCodes.rpc.internal,
@@ -523,7 +523,7 @@ export class JsonRpcEngine extends SafeEventEmitter {
     req: JsonRpcRequest<unknown>,
     res: PendingJsonRpcResponse<unknown>,
     error: unknown,
-  ) {
+  ): void {
     if (error instanceof Error) {
       if (error instanceof EthereumRpcError) {
         res.error = error;

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -81,13 +81,13 @@ export type JsonRpcMiddleware<T, U> = (
 ) => MaybePromise<void | JsonRpcEngineReturnHandler>;
 
 const errorMessages = {
-  invalidReturnHandler: (value: unknown) => `JsonRpcEngine: Return handlers must be functions. Received: ${typeof value}.`,
+  invalidReturnHandler: (value: unknown) => `JsonRpcEngine: Return handlers must be functions. Received: ${typeof value}`,
   noAssignmentToResponse: `JsonRpcEngine: The response "error" property must not be directly assigned. Throw errors instead.`,
   noErrorOrResult: `JsonRpcEngine: Response has no error or result`,
   noErrorsToEnd: `JsonRpcEngine: "end" callback must not be passed any values. Received an error. Throw errors instead.`,
   nonObjectRequest: (request: unknown) => `Requests must be plain objects. Received: ${typeof request}`,
   nonStringMethod: (method: unknown) => `Must specify a string method. Received: ${typeof method}`,
-  noValuesToEnd: (value: unknown) => `JsonRpcEngine: "end" callback must not be passed any values. Received: ${typeof value}.`,
+  noValuesToEnd: (value: unknown) => `JsonRpcEngine: "end" callback must not be passed any values. Received: ${typeof value}`,
   nothingEndedRequest: `JsonRpcEngine: Nothing ended request.`,
   threwNonError: `JsonRpcEngine: Middleware threw non-Error value.`,
 };

--- a/test/createScaffoldMiddleware.spec.js
+++ b/test/createScaffoldMiddleware.spec.js
@@ -14,9 +14,8 @@ describe('createScaffoldMiddleware', function () {
         res.result = 42;
         end();
       },
-      'method3': (_req, res, end) => {
-        res.error = new Error('method3');
-        end();
+      'method3': (_req, _res, _end) => {
+        throw new Error('method3');
       },
     };
 

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -222,7 +222,7 @@ describe('JsonRpcEngine', function () {
       assert.ok(res.error, 'should have error on response');
       assert.equal(res.error.code, -32603, 'should have expected error');
       assert.ok(
-        res.error.message.startsWith('JsonRpcEngine: return handlers must be functions.'),
+        res.error.message.startsWith('JsonRpcEngine: Return handlers must be functions.'),
         'should have expected error',
       );
       assert.ok(!res.result, 'should not have result on response');

--- a/test/engine.spec.js
+++ b/test/engine.spec.js
@@ -646,8 +646,9 @@ describe('JsonRpcEngine', function () {
 
     engine.handle(payload, (err, res) => {
       assert.ok(err, 'should have errored');
-      assert.ok(
-        err.message.startsWith('JsonRpcEngine: Nothing ended request:'),
+      assert.strictEqual(
+        err.message,
+        'JsonRpcEngine: Nothing ended request.',
         'should have expected error message',
       );
       assert.ok(!res.result, 'should not have result');


### PR DESCRIPTION
Pending: MetaMask/json-rpc-engine#83 

This attempts to address some of the concerns raised in MetaMask/core#1993, regarding the throwing of non-`Error` values. It doesn't fully resolve the issue, because the `async` signatures of `engine.handle` will _never_ reject, and will _only_ pass through middleware errors as plain object clones, without a `stack` property. The callback signature of `engine.handle` receives the thrown error as the first argument, in the style of Node.js.

**TODO**
- Figure out what to do with error stacks. See comments.