### PR TITLE
Handling an empty batch array in a request

### DIFF
--- a/src/JsonRpcEngine.test.ts
+++ b/src/JsonRpcEngine.test.ts
@@ -361,6 +361,41 @@ describe('JsonRpcEngine', () => {
     });
   });
 
+  it('handle: empty batch', async () => {
+    const engine = new JsonRpcEngine();
+    const emptyBatch = [] as any;
+
+    await new Promise<void>((resolve) => {
+      engine.handle(emptyBatch, function (error, response: any) {
+        expect(error).toBeNull();
+        expect(response).toBeInstanceOf(Array);
+        expect(response.length).toBe(1);
+        expect(
+          response[0].error.message.startsWith(
+            'Request batch must contain plain objects. Received an empty array',
+          ),
+        ).toBe(true);
+        expect(isJsonRpcSuccess(response[0])).toBe(false);
+        resolve();
+      });
+    });
+  });
+
+  it('handle: empty batch (async signature)', async () => {
+    const engine = new JsonRpcEngine();
+    const emptyBatch = [] as any;
+
+    const response: any = await engine.handle(emptyBatch);
+    expect(response).toBeInstanceOf(Array);
+    expect(response.length).toBe(1);
+    expect(
+      response[0].error.message.startsWith(
+        'Request batch must contain plain objects. Received an empty array',
+      ),
+    ).toBe(true);
+    expect(isJsonRpcSuccess(response[0])).toBe(false);
+  });
+
   it('handle: batch payloads', async () => {
     const engine = new JsonRpcEngine();
 

--- a/src/JsonRpcEngine.test.ts
+++ b/src/JsonRpcEngine.test.ts
@@ -369,7 +369,7 @@ describe('JsonRpcEngine', () => {
       engine.handle(emptyBatch, function (error, response: any) {
         expect(error).toBeNull();
         expect(response).toBeInstanceOf(Array);
-        expect(response.length).toBe(1);
+        expect(response).toHaveLength(1);
         expect(
           response[0].error.message.startsWith(
             'Request batch must contain plain objects. Received an empty array',
@@ -387,7 +387,7 @@ describe('JsonRpcEngine', () => {
 
     const response: any = await engine.handle(emptyBatch);
     expect(response).toBeInstanceOf(Array);
-    expect(response.length).toBe(1);
+    expect(response).toHaveLength(1);
     expect(
       response[0].error.message.startsWith(
         'Request batch must contain plain objects. Received an empty array',

--- a/src/JsonRpcEngine.ts
+++ b/src/JsonRpcEngine.ts
@@ -285,6 +285,24 @@ export class JsonRpcEngine extends SafeEventEmitter {
   ): Promise<JsonRpcResponse<Json>[] | void> {
     // The order here is important
     try {
+      // If the batch is an empty array, the response array must contain a single object
+      if (requests.length === 0) {
+        const response: JsonRpcResponse<Json>[] = [
+          {
+            id: null,
+            jsonrpc: '2.0',
+            error: new JsonRpcError(
+              errorCodes.rpc.invalidRequest,
+              'Request batch must contain plain objects. Received an empty array',
+            ),
+          },
+        ];
+        if (callback) {
+          return callback(null, response);
+        }
+        return response;
+      }
+
       // 2. Wait for all requests to finish, or throw on some kind of fatal
       // error
       const responses = (


### PR DESCRIPTION
In reference to _Batch_ section from [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification#batch):

![JSON-RPC 2 0 Specification - 1](https://github.com/MetaMask/json-rpc-engine/assets/23150023/e03d6ba4-d325-46a0-9eec-a4e33e19c5cc)
![JSON-RPC 2 0 Specification - 2](https://github.com/MetaMask/json-rpc-engine/assets/23150023/859475a3-1aaa-413b-a4c8-fdbb7d973607)

This PR includes:
- Solution for handling an empty batch array in a request. Upon receiving an empty batch array, the response array is now populated with a single object indicating the error.
- Addition of 2 new test functions to ensure proper validation and behavior of empty batch arrays.