### PR TITLE
applied eslint rules from core monorepo and fixed the errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,36 +1,134 @@
 module.exports = {
   root: true,
-
-  extends: ['@metamask/eslint-config'],
-
+  extends: ['@metamask/eslint-config', '@metamask/eslint-config-nodejs'],
+  ignorePatterns: [
+    '!.eslintrc.js',
+    '!jest.config.js',
+    'node_modules',
+    'dist',
+    'docs',
+    'coverage',
+  ],
   overrides: [
     {
-      files: ['*.ts'],
-      extends: ['@metamask/eslint-config-typescript'],
+      files: ['*.test.{ts,js}', '**/tests/**/*.{ts,js}'],
+      extends: ['@metamask/eslint-config-jest'],
+      rules: {
+        // TODO: Re-enable
+        'import/no-named-as-default-member': 'off',
+        'jest/no-conditional-expect': 'off',
+      },
     },
-
+    {
+      // These files are test helpers, not tests. We still use the Jest ESLint
+      // config here to ensure that ESLint expects a test-like environment, but
+      // various rules meant just to apply to tests have been disabled.
+      files: ['**/tests/**/*.{ts,js}', '!*.test.{ts,js}'],
+      rules: {
+        'jest/no-export': 'off',
+        'jest/require-top-level-describe': 'off',
+        'jest/no-if': 'off',
+        'jest/no-test-return-statement': 'off',
+        // TODO: Re-enable this rule; we can accomodate this even in our test helpers
+        'jest/expect-expect': 'off',
+      },
+    },
     {
       files: ['*.js'],
       parserOptions: {
         sourceType: 'script',
+        ecmaVersion: '2018',
       },
-      extends: ['@metamask/eslint-config-nodejs'],
     },
-
     {
-      files: ['*.test.ts', '*.test.js'],
-      extends: [
-        '@metamask/eslint-config-jest',
-        '@metamask/eslint-config-nodejs',
-      ],
+      files: ['*.ts'],
+      extends: ['@metamask/eslint-config-typescript'],
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: ['./tsconfig.json'],
+      },
+      rules: {
+        // disabled due to incompatibility with Record<string, unknown>
+        // See https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440
+        '@typescript-eslint/consistent-type-definitions': 'off',
+
+        // TODO: auto-fix breaks stuff
+        '@typescript-eslint/promise-function-async': 'off',
+
+        // TODO: re-enble most of these rules
+        '@typescript-eslint/await-thenable': 'warn',
+        '@typescript-eslint/naming-convention': 'off',
+        '@typescript-eslint/no-floating-promises': 'warn',
+        '@typescript-eslint/no-for-in-array': 'warn',
+        '@typescript-eslint/no-loss-of-precision': 'warn',
+        '@typescript-eslint/no-misused-promises': 'warn',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+        '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/prefer-enum-initializers': 'off',
+        '@typescript-eslint/prefer-nullish-coalescing': 'off',
+        '@typescript-eslint/prefer-optional-chain': 'off',
+        '@typescript-eslint/prefer-reduce-type-parameter': 'off',
+        '@typescript-eslint/restrict-plus-operands': 'warn',
+        '@typescript-eslint/restrict-template-expressions': 'warn',
+        'no-restricted-syntax': 'off',
+        'no-restricted-globals': 'off',
+      },
+    },
+    {
+      files: ['tests/setupAfterEnv/matchers.ts'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+    },
+    {
+      files: ['*.d.ts'],
+      rules: {
+        '@typescript-eslint/naming-convention': 'warn',
+        'import/unambiguous': 'off',
+      },
+    },
+    {
+      files: ['scripts/*.ts'],
+      rules: {
+        // All scripts will have shebangs.
+        'n/shebang': 'off',
+      },
     },
   ],
+  rules: {
+    // Left disabled because various properties throughough this repo are snake_case because the
+    // names come from external sources or must comply with standards
+    // e.g. `txreceipt_status`, `signTypedData_v4`, `token_id`
+    camelcase: 'off',
+    'id-length': 'off',
 
-  ignorePatterns: [
-    '!.eslintrc.js',
-    '!.prettierrc.js',
-    'dist/',
-    'docs/',
-    '.yarn/',
-  ],
+    // TODO: re-enble most of these rules
+    '@typescript-eslint/naming-convention': 'off',
+    'function-paren-newline': 'off',
+    'guard-for-in': 'off',
+    'id-denylist': 'off',
+    'implicit-arrow-linebreak': 'off',
+    'import/no-anonymous-default-export': 'off',
+    'import/no-unassigned-import': 'off',
+    'lines-around-comment': 'off',
+    'n/no-sync': 'off',
+    'no-async-promise-executor': 'off',
+    'no-case-declarations': 'off',
+    'no-invalid-this': 'off',
+    'no-negated-condition': 'off',
+    'no-new': 'off',
+    'no-param-reassign': 'off',
+    'no-restricted-syntax': 'off',
+    radix: 'off',
+    'require-atomic-updates': 'off',
+    'jsdoc/match-description': [
+      'off',
+      { matchDescription: '^[A-Z`\\d_][\\s\\S]*[.?!`>)}]$' },
+    ],
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "depcheck": "^1.4.3",
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.5",
     "eslint-plugin-jsdoc": "^39.6.2",

--- a/src/createAsyncMiddleware.ts
+++ b/src/createAsyncMiddleware.ts
@@ -71,7 +71,7 @@ export function createAsyncMiddleware<
         returnHandlerCallback = runReturnHandlersCallback;
         resolveNextPromise();
       });
-      await nextPromise;
+      return nextPromise;
     };
 
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,6 +1005,7 @@ __metadata:
     depcheck: ^1.4.3
     eslint: ^8.27.0
     eslint-config-prettier: ^8.5.0
+    eslint-import-resolver-typescript: ^2.5.0
     eslint-plugin-import: ^2.26.0
     eslint-plugin-jest: ^27.1.5
     eslint-plugin-jsdoc: ^39.6.2
@@ -2730,6 +2731,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-import-resolver-typescript@npm:^2.5.0":
+  version: 2.7.1
+  resolution: "eslint-import-resolver-typescript@npm:2.7.1"
+  dependencies:
+    debug: ^4.3.4
+    glob: ^7.2.0
+    is-glob: ^4.0.3
+    resolve: ^1.22.0
+    tsconfig-paths: ^3.14.1
+  peerDependencies:
+    eslint: "*"
+    eslint-plugin-import: "*"
+  checksum: 1d81b657b1f73bf95b8f0b745c0305574b91630c1db340318f3ca8918e206fce20a933b95e7c419338cc4452cb80bb2b2d92acaf01b6aa315c78a332d832545c
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.7.4":
   version: 2.7.4
   resolution: "eslint-module-utils@npm:2.7.4"
@@ -3382,6 +3399,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.2.0":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.1.1
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
+  languageName: node
+  linkType: hard
+
 "glob@npm:^8.0.1":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
@@ -3770,6 +3801,15 @@ __metadata:
   dependencies:
     has: ^1.0.3
   checksum: f7f7eb2ab71fd769ee9fb2385c095d503aa4b5ce0028c04557de03f1e67a87c85e5bac1f215945fc3c955867a139a415a3ec4c4234a0bffdf715232660f440a6
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.13.0":
+  version: 2.13.0
+  resolution: "is-core-module@npm:2.13.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: 053ab101fb390bfeb2333360fd131387bed54e476b26860dc7f5a700bbf34a0ec4454f7c8c4d43e8a0030957e4b3db6e16d35e1890ea6fb654c833095e040355
   languageName: node
   linkType: hard
 
@@ -4783,7 +4823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -5541,6 +5581,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.0":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
+  dependencies:
+    is-core-module: ^2.13.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: f8a26958aa572c9b064562750b52131a37c29d072478ea32e129063e2da7f83e31f7f11e7087a18225a8561cfe8d2f0df9dbea7c9d331a897571c0a2527dbb4c
+  languageName: node
+  linkType: hard
+
 "resolve@patch:resolve@^1.18.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.2
   resolution: "resolve@patch:resolve@npm%3A1.22.2#~builtin<compat/resolve>::version=1.22.2&hash=c3c19d"
@@ -5551,6 +5604,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 66cc788f13b8398de18eb4abb3aed90435c84bb8935953feafcf7231ba4cd191b2c10b4a87b1e9681afc34fb138c705f91f7330ff90bfa36f457e5584076a2b8
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
+  dependencies:
+    is-core-module: ^2.13.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5479b7d431cacd5185f8db64bfcb7286ae5e31eb299f4c4f404ad8aa6098b77599563ac4257cb2c37a42f59dfc06a1bec2bcf283bb448f319e37f0feb9a09847
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
We are in the process of migrating json-rpc-engine repo into core monorepo. Before migrating, we want to make sure the source repo is aligned in terms of eslint versions and rules.

In this PR, 

- Applied eslint rules from the core monorepo
- Fixed errors due to new eslint rules from the core monorepo

## References
- See https://github.com/MetaMask/core/pull/1804#issuecomment-1766536966