### PR TITLE
Updated the migration status in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `@metamask/json-rpc-engine`
 
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over.</p></td></tr></table>
+
 A tool for processing JSON-RPC requests and responses.
 
 ## Usage


### PR DESCRIPTION
We are in the process of migrating json-rpc-engine to core monorepo. In this PR, we have updated the readme to alert the contributors on the same.